### PR TITLE
Update iteritems() to python3 compatibility

### DIFF
--- a/pykliep.py
+++ b/pykliep.py
@@ -1,6 +1,6 @@
 import numpy as np
 import warnings
-
+from future.utils import iteritems
 class DensityRatioEstimator:
     """
     Class to accomplish direct density estimation implementing the original KLIEP 
@@ -83,7 +83,7 @@ class DensityRatioEstimator:
                                                          sigma=sigma)
                     j_scores[(num_param,sigma)] = np.mean(j_scores[(num_param,sigma)])
 
-            sorted_scores = sorted([x for x in j_scores.iteritems() if np.isfinite(x[1])], key=lambda x :x[1], reverse=True)
+            sorted_scores = sorted([x for x in iteritems(j_scores) if np.isfinite(x[1])], key=lambda x :x[1], reverse=True)
             if len(sorted_scores) == 0:
                 warnings.warn('LCV failed to converge for all values of sigma.')
                 return self


### PR DESCRIPTION
Add compatibility with Python3 for iteritems() to fix #4 
This change adds compatibility for both Python2.6/2.7 and Python3.x, as recommended [here](
http://docs.buildbot.net/0.9.4/developer/py3-compat.html)

